### PR TITLE
scorpion_windy: use own fstab

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -16,6 +16,8 @@ include device/sony/shinano/BoardConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := SGP611
 
+TARGET_RECOVERY_FSTAB = device/sony/scorpion/rootdir/fstab.shinano
+
 BOARD_USERDATAIMAGE_PARTITION_SIZE := 12253641728
 
 #BOARD_KERNEL_CMDLINE += mem=1281M@255M mem=1407M@2048M


### PR DESCRIPTION
override device/sony/scorpion/rootdir/fstab.shinano due to different mount path

aries castor castor_windy leo use: /devices/msm_sdcc.2/mmc_host for sdcard1
scorpion scorpion_windy use: /devices/msm_sdcc.3/mmc_host for sdcard1

Signed-off-by: David Viteri davidteri91@gmail.com
