### PR TITLE
scorpion_windy: Update NFC NXP HAL naming

### DIFF
--- a/aosp_sgp611_windy.mk
+++ b/aosp_sgp611_windy.mk
@@ -16,6 +16,10 @@ TARGET_KERNEL_CONFIG := aosp_shinano_scorpion_defconfig
 
 $(call inherit-product, device/sony/scorpion/aosp_sgp621_common.mk)
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.scorpion_windy
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=scorpion_windy
+
 PRODUCT_NAME := aosp_sgp611_windy
 PRODUCT_DEVICE := scorpion_windy
 PRODUCT_MODEL := Xperia Z3 Tablet Compact WiFi(AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba humberos@gmail.com
